### PR TITLE
startup server if it's not running

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ For the full article and guide visit https://jamesachambers.com/raspberry-pi-min
 To get started type:<br>
 
 ```
-wget https://raw.githubusercontent.com/TheRemote/RaspberryPiMinecraft/master/SetupMinecraft.sh
-chmod +x SetupMinecraft.sh
-./SetupMinecraft.sh
+wget https://raw.githubusercontent.com/TheRemote/RaspberryPiMinecraft/master/SetupMinecraft.sh && chmod +x SetupMinecraft.sh && ./SetupMinecraft.sh
 ```
 <h2>Getting Help</h2>
 To get help you may open an issue here or visit my web site at https://jamesachambers.com/raspberry-pi-minecraft-server-script-with-startup-service/ which contains lots of comments from myself and users helping each other out!

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note that for this to work the Paper Minecraft server must also have released th
 
 <h2>Check Java Version</h2>
 
-<p>Sometimes if you have multiple versions of Java installed the wrong version of Java will be selected as the default.  If the server didn't start check that the right version of Java is selected with this command:</p>
+<p>Sometimes if you have multiple versions of Java installed the wrong version of Java will be selected as the default.  If the server didn't start check that the right version of Java is selected with this command: <code>java -version</code></p>
 <p>If you get the message "<em>update-alternatives: error: no alternatives for java</em>" then you only have one version of Java installed and can skip to the next section.</p>
 <p>If you are presented with a list of choices then your machine has multiple versions of Java installed.  It will look like this:</p>
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ For the full article and guide visit https://jamesachambers.com/raspberry-pi-min
 
 <h2>Installation Instructions</h2>
 To get started type:<br>
-wget https://raw.githubusercontent.com/TheRemote/RaspberryPiMinecraft/master/SetupMinecraft.sh<br>
-chmod +x SetupMinecraft.sh<br>
-./SetupMinecraft.sh<br>
 
+```
+wget https://raw.githubusercontent.com/TheRemote/RaspberryPiMinecraft/master/SetupMinecraft.sh
+chmod +x SetupMinecraft.sh
+./SetupMinecraft.sh
+```
 <h2>Getting Help</h2>
 To get help you may open an issue here or visit my web site at https://jamesachambers.com/raspberry-pi-minecraft-server-script-with-startup-service/ which contains lots of comments from myself and users helping each other out!
 

--- a/SetupMinecraft.sh
+++ b/SetupMinecraft.sh
@@ -109,7 +109,7 @@ Update_Scripts() {
 
   # Download update.sh from repository
   echo "Grabbing update.sh from repository..."
-  wget -O restart.sh https://raw.githubusercontent.com/TheRemote/RaspberryPiMinecraft/master/update.sh
+  wget -O update.sh https://raw.githubusercontent.com/TheRemote/RaspberryPiMinecraft/master/update.sh
   chmod +x update.sh
   sed -i "s:dirname:$DirName:g" update.sh
 

--- a/SetupMinecraft.sh
+++ b/SetupMinecraft.sh
@@ -107,6 +107,12 @@ Update_Scripts() {
   chmod +x restart.sh
   sed -i "s:dirname:$DirName:g" restart.sh
 
+  # Download update.sh from repository
+  echo "Grabbing update.sh from repository..."
+  wget -O restart.sh https://raw.githubusercontent.com/TheRemote/RaspberryPiMinecraft/master/update.sh
+  chmod +x update.sh
+  sed -i "s:dirname:$DirName:g" update.sh
+
   # Download permissions.sh from repository
   echo "Grabbing fixpermissions.sh from repository..."
   wget -O fixpermissions.sh https://raw.githubusercontent.com/TheRemote/RaspberryPiMinecraft/master/fixpermissions.sh

--- a/restart.sh
+++ b/restart.sh
@@ -7,28 +7,24 @@
 # Check if server is running
 if ! screen -list | grep -q "\.minecraft"; then
     echo "Server is not currently running!"
-    exit 1
+    echo "Starting up server now..."
+    ./start.sh
 fi
 
 echo "Sending restart notifications to server..."
 
 # Minecraft Server restart and pi reboot.
-screen -Rd minecraft -X stuff "say Server is restarting in 30 seconds! $(printf '\r')"
-sleep 23s
-screen -Rd minecraft -X stuff "say Server is restarting in 7 seconds! $(printf '\r')"
-sleep 1s
-screen -Rd minecraft -X stuff "say Server is restarting in 6 seconds! $(printf '\r')"
-sleep 1s
-screen -Rd minecraft -X stuff "say Server is restarting in 5 seconds! $(printf '\r')"
-sleep 1s
-screen -Rd minecraft -X stuff "say Server is restarting in 4 seconds! $(printf '\r')"
-sleep 1s
-screen -Rd minecraft -X stuff "say Server is restarting in 3 seconds! $(printf '\r')"
-sleep 1s
-screen -Rd minecraft -X stuff "say Server is restarting in 2 seconds! $(printf '\r')"
-sleep 1s
-screen -Rd minecraft -X stuff "say Server is restarting in 1 second! $(printf '\r')"
-sleep 1s
+counter="30"
+while [ ${counter} -gt 0 ]; do
+	if [[ "${counter}" =~ ^(30|7|6|5|4|3|2)$ ]]; then
+    screen -Rd minecraft -X stuff "say Server is restarting in ${counter} seconds! $(printf '\r')"
+	fi
+  if [[ "${counter}" = 1 ]]; then
+    screen -Rd minecraft -X stuff "say Server is restarting in ${counter} second! $(printf '\r')"
+  fi
+	counter=$((counter-1))
+	sleep 1s
+done
 screen -Rd minecraft -X stuff "say Closing server...$(printf '\r')"
 screen -Rd minecraft -X stuff "stop $(printf '\r')"
 

--- a/restart.sh
+++ b/restart.sh
@@ -9,6 +9,7 @@ if ! screen -list | grep -q "\.minecraft"; then
     echo "Server is not currently running!"
     echo "Starting up server now..."
     ./start.sh
+    exit 1
 fi
 
 echo "Sending restart notifications to server..."

--- a/restart.sh
+++ b/restart.sh
@@ -17,11 +17,11 @@ echo "Sending restart notifications to server..."
 counter="30"
 while [ ${counter} -gt 0 ]; do
 	if [[ "${counter}" =~ ^(30|7|6|5|4|3|2)$ ]]; then
-    screen -Rd minecraft -X stuff "say Server is restarting in ${counter} seconds! $(printf '\r')"
+		screen -Rd minecraft -X stuff "say Server is restarting in ${counter} seconds! $(printf '\r')"
 	fi
-  if [[ "${counter}" = 1 ]]; then
-    screen -Rd minecraft -X stuff "say Server is restarting in ${counter} second! $(printf '\r')"
-  fi
+	if [[ "${counter}" = 1 ]]; then
+		screen -Rd minecraft -X stuff "say Server is restarting in ${counter} second! $(printf '\r')"
+	fi
 	counter=$((counter-1))
 	sleep 1s
 done

--- a/restart.sh
+++ b/restart.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Author: James A. Chambers - https://jamesachambers.com/
 # More information at https://jamesachambers.com/raspberry-pi-minecraft-server-script-with-startup-service/
 # GitHub Repository: https://github.com/TheRemote/RaspberryPiMinecraft

--- a/update.sh
+++ b/update.sh
@@ -1,40 +1,67 @@
 #!/bin/bash
 # this script updates your server to the latest version available
 
+# parse script arguments
+force=false
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-f)
+			force=true
+		;;
+		--force)
+			force=true
+		;;
+		*)
+			echo "bad argument: $1"
+			exit 1
+		;;
+	esac
+	shift
+done
+
 # change to server directory
 cd dirname/minecraft/
 
-# execute stop script
-./stop.sh
+# check server status
+if screen -list | grep -q "\.minecraft"; then
+	echo "server is running - stopping server before update"
+	# execute stop script
+	./stop.sh
+else
+	echo "server is not running - updating now"
+fi
 
-# ask user for update
-echo "Would you like to update your server to the latest version available?"
-read -p "Your choice [Y/N]: " choice
-regex="^(Y|y|N|n)$"
-while [[ ! ${choice} =~ ${regex} ]]; do
-	read -p "Please press Y or N: " choice
-done
-if ! [[ $choice =~ ^[Yy]$ ]]; then
-	echo "abording update..."
-	./start.sh
-	exit 1
+# check if user wants to force update
+if ! [[ ${force} == true ]]; then
+	# ask user for update
+	echo "Would you like to update your server to the latest version available?"
+	read -p "Your choice [Y/N]: " choice
+	regex="^(Y|y|N|n)$"
+	while [[ ! ${choice} =~ ${regex} ]]; do
+		read -p "Please press Y or N: " choice
+	done
+	if ! [[ $choice =~ ^[Yy]$ ]]; then
+		echo "abording update..."
+		./start.sh
+		exit 1
+	fi
 fi
 
 # grep latest verion from papermc.io
 Version=$(wget -q -O - https://papermc.io/api/v2/projects/paper | rev | cut -d, -f1 | rev)
 Version="${Version:1}"
 Version="${Version::-3}"
-echo "latest server version seems to be $Version"
-echo "trying to update to version $Version ..."
+echo "latest server version seems to be ${Version}"
+echo "trying to update to version ${Version} ..."
 
 # test if papermc is avalable and update on success
-wget --spider --quiet https://papermc.io/api/v1/paper/$Version/latest/download
+wget --spider --quiet https://papermc.io/api/v1/paper/${Version}/latest/download
 if [ "$?" != 0 ]; then
 	echo "Warning: Unable to connect to papermc API. Skipping update..."
 else
 	echo "Success: Updating to latest papermc version..."
 	rm paperclip.jar
-	wget -q -O paperclip.jar https://papermc.io/api/v1/paper/$Version/latest/download
+	wget -q -O paperclip.jar https://papermc.io/api/v1/paper/${Version}/latest/download
 fi
 
 # execute start script

--- a/update.sh
+++ b/update.sh
@@ -1,14 +1,28 @@
 #!/bin/bash
 # this script updates your server to the latest version available
 
-# defines papermc server version
-Version="1.16.5"
-
 # change to server directory
 cd dirname/minecraft/
 
 # execute stop script
 ./stop.sh
+
+# ask user for desired update version
+echo "To which server version would you like to update? Example: 1.16.5"
+read -p "Your Version: " Version
+VersionExists=false
+while [[ $VersionExists == false ]]; do
+	echo "checking availability of server version $Version ..."
+	wget --spider --quiet https://papermc.io/api/v1/paper/$Version/latest/download
+	if [ "$?" != 0 ]; then
+		VersionExists=false
+		echo "Version $Version does not exists (yet) - please try anotherone"
+		read -p "Your Version: " Version
+	else
+		echo "Version $Version exists! - updating server..."
+		VersionExists=true
+	fi
+done
 
 # test if papermc is avalable and update on success
 wget --spider --quiet https://papermc.io/api/v1/paper/$Version/latest/download

--- a/update.sh
+++ b/update.sh
@@ -7,6 +7,19 @@ cd dirname/minecraft/
 # execute stop script
 ./stop.sh
 
+# ask user for update
+echo "Would you like to update your server to the latest version available?"
+read -p "Your choice [Y/N]: " choice
+regex="^(Y|y|N|n)$"
+while [[ ! ${choice} =~ ${regex} ]]; do
+	read -p "Please press Y or N: " choice
+done
+if ! [[ $choice =~ ^[Yy]$ ]]; then
+	echo "abording update..."
+	./start.sh
+	exit 1
+fi
+
 # grep latest verion from papermc.io
 Version=$(wget -q -O - https://papermc.io/api/v2/projects/paper | rev | cut -d, -f1 | rev)
 Version="${Version:1}"

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# this script updates your server to the latest version available
+
+# defines papermc server version
+Version="1.16.5"
+
+# change to server directory
+cd dirname/minecraft/
+
+# execute stop script
+./stop.sh
+
+# test if papermc is avalable and update on success
+wget --spider --quiet https://papermc.io/api/v1/paper/$Version/latest/download
+if [ "$?" != 0 ]; then
+	echo "Warning: Unable to connect to papermc API. Skipping update..."
+else
+	echo "Success: Updating to latest papermc version..."
+	rm paperclip.jar
+	wget -q -O paperclip.jar https://papermc.io/api/v1/paper/$Version/latest/download
+fi
+
+# execute start script
+./start.sh

--- a/update.sh
+++ b/update.sh
@@ -7,22 +7,12 @@ cd dirname/minecraft/
 # execute stop script
 ./stop.sh
 
-# ask user for desired update version
-echo "To which server version would you like to update? Example: 1.16.5"
-read -p "Your Version: " Version
-VersionExists=false
-while [[ $VersionExists == false ]]; do
-	echo "checking availability of server version $Version ..."
-	wget --spider --quiet https://papermc.io/api/v1/paper/$Version/latest/download
-	if [ "$?" != 0 ]; then
-		VersionExists=false
-		echo "Version $Version does not exists (yet) - please try anotherone"
-		read -p "Your Version: " Version
-	else
-		echo "Version $Version exists! - updating server..."
-		VersionExists=true
-	fi
-done
+# grep latest verion from papermc.io
+Version=$(wget -q -O - https://papermc.io/api/v2/projects/paper | rev | cut -d, -f1 | rev)
+Version="${Version:1}"
+Version="${Version::-3}"
+echo "latest server version seems to be $Version"
+echo "trying to update to version $Version ..."
 
 # test if papermc is avalable and update on success
 wget --spider --quiet https://papermc.io/api/v1/paper/$Version/latest/download


### PR DESCRIPTION
My main idea would be if someone has the restart script running daily as an example and the server goes down it would startup automatically on the next execution of restart.sh instead of telling you that there is no server running. 
Also I combined some countdown messages. 
I think the three install commands in README.md, they could be in a code box because they are rather essential for users.
Feel free to edit or change it to suit your needs ;-)
FYI I noticed one could provide a single line of code that downloads, makes executable and executes your SetupMinecraft.sh script. 
I added an update script on request of @capsload2 which updates to the latest version available on papermc.io.